### PR TITLE
make constant entities use a manually set id

### DIFF
--- a/REAMDE.md
+++ b/REAMDE.md
@@ -5,18 +5,18 @@ For Java 17+
 make sure maven is installed on your local machine
 make sure JAVA_HOME path has been set to point to a Java 17 JDK
 
-#### to test&run locally, run the following commands in console:
+### to test&run locally, run the following commands in console:
 
 - run: mvn clean install
 - run: mvn spring-boot:run
 
-#### to compile and run from jar (the compiled jar is likely what will be deployed to a server)
+### to compile and run from jar (the compiled jar is likely what will be deployed to a server)
 
 - run: mvn clean install
 - run: cd target
 - run: java -jar spring.work.assessment-1.0.0.jar
 
-#### post-run info
+## post-run info
 
 ##### logs are saved in logstash folder where the app is running
 

--- a/src/main/java/com/kingprice/insurance/springworkassessment/domain/formula/FormulaInputParam.java
+++ b/src/main/java/com/kingprice/insurance/springworkassessment/domain/formula/FormulaInputParam.java
@@ -35,7 +35,8 @@ public abstract class FormulaInputParam extends BaseEntity implements Serializab
 
     public FormulaInputParam() {}
 
-    public FormulaInputParam(String name, String description, InputParamSpecification inputParamSpecification) {
+    public FormulaInputParam(Long id, String name, String description, InputParamSpecification inputParamSpecification) {
+        this.id = id;
         this.name = name;
         this.description = description;
         this.inputParamSpecification = inputParamSpecification;

--- a/src/main/java/com/kingprice/insurance/springworkassessment/domain/formula/FormulaType.java
+++ b/src/main/java/com/kingprice/insurance/springworkassessment/domain/formula/FormulaType.java
@@ -13,7 +13,7 @@ import static com.kingprice.insurance.springworkassessment.GlobalConstants.STAND
 @LinkedRepository(FormulaTypeRepository.class)
 public class FormulaType extends BaseEntity {
     public static final String CONVERSION_FORMULA_TYPE_NAME = "CONVERSION_FORMULA_TYPE";
-    public static final FormulaType CONVERSION_FORMULA_TYPE = new FormulaType(CONVERSION_FORMULA_TYPE_NAME);
+    public static final FormulaType CONVERSION_FORMULA_TYPE = new FormulaType(1L,CONVERSION_FORMULA_TYPE_NAME);
 
     @Column(name="id")
     @Id
@@ -27,7 +27,8 @@ public class FormulaType extends BaseEntity {
 
     public FormulaType() {}
 
-    public FormulaType(String name) {
+    public FormulaType(Long id, String name) {
+        this.id = id;
         this.name = name;
     }
 

--- a/src/main/java/com/kingprice/insurance/springworkassessment/domain/formula/MeasurementUnit.java
+++ b/src/main/java/com/kingprice/insurance/springworkassessment/domain/formula/MeasurementUnit.java
@@ -19,20 +19,20 @@ public class MeasurementUnit extends FormulaInputParam {
     @JoinColumn(name = "measurement_system_id")
     private MeasurementUnitSystem measurementSystem;
 
-    public static final MeasurementUnit MILLIMETER = new MeasurementUnit("MILLIMETER", "Millimeter", METRIC_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
-    public static final MeasurementUnit CENTIMETER = new MeasurementUnit("CENTIMETER", "Centimeters", METRIC_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
-    public static final MeasurementUnit METER = new MeasurementUnit("METER", "Meters", METRIC_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
-    public static final MeasurementUnit KILOMETER = new MeasurementUnit("KILOMETER", "Kilometer", METRIC_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
+    public static final MeasurementUnit MILLIMETER = new MeasurementUnit(1L,"MILLIMETER", "Millimeter", METRIC_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
+    public static final MeasurementUnit CENTIMETER = new MeasurementUnit(2L,"CENTIMETER", "Centimeters", METRIC_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
+    public static final MeasurementUnit METER = new MeasurementUnit(3L,"METER", "Meters", METRIC_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
+    public static final MeasurementUnit KILOMETER = new MeasurementUnit(4L,"KILOMETER", "Kilometer", METRIC_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
 
-    public static final MeasurementUnit INCH = new MeasurementUnit("INCH", "Inches", IMPERIAL_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
-    public static final MeasurementUnit FOOT = new MeasurementUnit("FOOT", "Feet", IMPERIAL_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
-    public static final MeasurementUnit YARD = new MeasurementUnit("YARD", "Yards", IMPERIAL_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
-    public static final MeasurementUnit MILE = new MeasurementUnit("MILE", "Miles", IMPERIAL_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
+    public static final MeasurementUnit INCH = new MeasurementUnit(5L,"INCH", "Inches", IMPERIAL_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
+    public static final MeasurementUnit FOOT = new MeasurementUnit(6L,"FOOT", "Feet", IMPERIAL_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
+    public static final MeasurementUnit YARD = new MeasurementUnit(7L,"YARD", "Yards", IMPERIAL_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
+    public static final MeasurementUnit MILE = new MeasurementUnit(8L,"MILE", "Miles", IMPERIAL_SYSTEM, GENERIC_NUMBER_DECIMAL_INPUT_PARAM);
 
     public MeasurementUnit() {}
 
-    public MeasurementUnit(String name, String description, MeasurementUnitSystem measurementSystem, InputParamSpecification inputParamSpecification) {
-        super(name,description, inputParamSpecification);
+    public MeasurementUnit(Long id, String name, String description, MeasurementUnitSystem measurementSystem, InputParamSpecification inputParamSpecification) {
+        super(id,name,description, inputParamSpecification);
         this.measurementSystem = measurementSystem;
     }
 

--- a/src/main/java/com/kingprice/insurance/springworkassessment/domain/formula/MeasurementUnitSystem.java
+++ b/src/main/java/com/kingprice/insurance/springworkassessment/domain/formula/MeasurementUnitSystem.java
@@ -14,8 +14,8 @@ import static com.kingprice.insurance.springworkassessment.GlobalConstants.STAND
 @Entity(name = "measurement_unit_system")
 @LinkedRepository(MeasurementUnitSystemRepository.class)
 public class MeasurementUnitSystem extends BaseEntity implements Serializable {
-    public static final MeasurementUnitSystem IMPERIAL_SYSTEM = new MeasurementUnitSystem("IMPERIAL_SYSTEM");
-    public static final MeasurementUnitSystem METRIC_SYSTEM = new MeasurementUnitSystem("METRIC_SYSTEM");
+    public static final MeasurementUnitSystem IMPERIAL_SYSTEM = new MeasurementUnitSystem(1L,"IMPERIAL_SYSTEM");
+    public static final MeasurementUnitSystem METRIC_SYSTEM = new MeasurementUnitSystem(2L,"METRIC_SYSTEM");
 
     @Id
     @GeneratedValue(strategy=GenerationType.IDENTITY)
@@ -28,7 +28,8 @@ public class MeasurementUnitSystem extends BaseEntity implements Serializable {
 
     public MeasurementUnitSystem() {}
 
-    public MeasurementUnitSystem(String name) {
+    public MeasurementUnitSystem(Long id, String name) {
+        this.id = id;
         this.name = name;
     }
 

--- a/src/main/java/com/kingprice/insurance/springworkassessment/domain/formula/MeasurementUnitToMeasurementUnitConversionFactor.java
+++ b/src/main/java/com/kingprice/insurance/springworkassessment/domain/formula/MeasurementUnitToMeasurementUnitConversionFactor.java
@@ -17,31 +17,37 @@ import static com.kingprice.insurance.springworkassessment.domain.formula.Measur
 public class MeasurementUnitToMeasurementUnitConversionFactor extends BaseEntity implements Serializable {
 
     public static final MeasurementUnitToMeasurementUnitConversionFactor METER_TO_FOOT = new MeasurementUnitToMeasurementUnitConversionFactor()
+            .withId(1L)
             .withFromMeasurementUnit(METER)
             .withToMeasurementUnit(FOOT)
             .withConversionFactor(3.28084D);
 
     public static final MeasurementUnitToMeasurementUnitConversionFactor FOOT_TO_METER = new MeasurementUnitToMeasurementUnitConversionFactor()
+            .withId(2L)
             .withFromMeasurementUnit(FOOT)
             .withToMeasurementUnit(METER)
             .withConversionFactor(0.3048D);
 
     public static final MeasurementUnitToMeasurementUnitConversionFactor CENTIMETER_TO_INCH = new MeasurementUnitToMeasurementUnitConversionFactor()
+            .withId(3L)
             .withFromMeasurementUnit(CENTIMETER)
             .withToMeasurementUnit(INCH)
             .withConversionFactor(0.393701D);
 
     public static final MeasurementUnitToMeasurementUnitConversionFactor INCH_TO_CENTIMETER = new MeasurementUnitToMeasurementUnitConversionFactor()
+            .withId(4L)
             .withFromMeasurementUnit(INCH)
             .withToMeasurementUnit(CENTIMETER)
             .withConversionFactor(2.5400013716D);
 
     public static final MeasurementUnitToMeasurementUnitConversionFactor KILOMETER_TO_MILE = new MeasurementUnitToMeasurementUnitConversionFactor()
+            .withId(5L)
             .withFromMeasurementUnit(KILOMETER)
             .withToMeasurementUnit(MILE)
             .withConversionFactor(0.6213715277778D);
 
     public static final MeasurementUnitToMeasurementUnitConversionFactor MILE_TO_KILOMETER = new MeasurementUnitToMeasurementUnitConversionFactor()
+            .withId(6L)
             .withFromMeasurementUnit(MILE)
             .withToMeasurementUnit(KILOMETER)
             .withConversionFactor(1.6093448690458176387D);
@@ -80,6 +86,11 @@ public class MeasurementUnitToMeasurementUnitConversionFactor extends BaseEntity
         this.fromMeasurementUnit = fromMeasurementUnit;
         this.toMeasurementUnit = toMeasurementUnit;
         this.conversionFactor = conversionFactor;
+    }
+
+    public MeasurementUnitToMeasurementUnitConversionFactor withId(Long id) {
+        this.id = id;
+        return this;
     }
 
     public MeasurementUnitToMeasurementUnitConversionFactor withFromMeasurementUnit(MeasurementUnit fromMeasurementUnit) {

--- a/src/main/java/com/kingprice/insurance/springworkassessment/domain/shared/InputParamSpecification.java
+++ b/src/main/java/com/kingprice/insurance/springworkassessment/domain/shared/InputParamSpecification.java
@@ -15,16 +15,20 @@ import java.io.Serializable;
 public class InputParamSpecification extends BaseEntity implements Serializable {
 
     public static final InputParamSpecification GENERIC_NUMBER_DECIMAL_INPUT_PARAM = new InputParamSpecification()
+            .withId(1L)
             .withStepSizeAllowed(0.00000000001D);
 
     public static final InputParamSpecification GENERIC_INTEGER_INPUT_PARAM = new InputParamSpecification()
+            .withId(2L)
             .withStepSizeAllowed(1.00D);
 
     public static final InputParamSpecification INTEGER_POSITIVE_INPUT_PARAM = new InputParamSpecification()
+            .withId(3L)
             .withMinValueAllowed(0.00D)
             .withStepSizeAllowed(1.00D);
 
     public static final InputParamSpecification INTEGER_NEGATIVE_INPUT_PARAM = new InputParamSpecification()
+            .withId(4L)
             .withMaxValueAllowed(0.00D)
             .withStepSizeAllowed(1.00D);
 
@@ -52,6 +56,21 @@ public class InputParamSpecification extends BaseEntity implements Serializable 
 
     public InputParamSpecification() {}
 
+    public InputParamSpecification(Long id,
+                                   Double minValueAllowed,
+                                   Double maxValueAllowed,
+                                   Double stepSizeAllowed) {
+        this.id = id;
+        this.minValueAllowed = minValueAllowed;
+        this.maxValueAllowed = maxValueAllowed;
+        this.stepSizeAllowed = stepSizeAllowed;
+    }
+
+    public InputParamSpecification withId(Long id) {
+        this.id = id;
+        return this;
+    }
+
     public InputParamSpecification withMinValueAllowed(Double minValueAllowed) {
         this.minValueAllowed = minValueAllowed;
         return this;
@@ -65,16 +84,6 @@ public class InputParamSpecification extends BaseEntity implements Serializable 
     public InputParamSpecification withStepSizeAllowed(Double stepSizeAllowed) {
         this.stepSizeAllowed = stepSizeAllowed;
         return this;
-    }
-
-    public InputParamSpecification(Long id,
-                                   Double minValueAllowed,
-                                   Double maxValueAllowed,
-                                   Double stepSizeAllowed) {
-        this.id = id;
-        this.minValueAllowed = minValueAllowed;
-        this.maxValueAllowed = maxValueAllowed;
-        this.stepSizeAllowed = stepSizeAllowed;
     }
 
     public Long getId() {


### PR DESCRIPTION
helps with data integrity, even if a migration script adds a record with a id that a constant entity is using it will fail quickly which is good